### PR TITLE
Force and ForceErrors

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -13,23 +13,13 @@ import (
 type Cache struct {
 	// Directory where the cache is stored. Defaults to gohttpdisk.
 	Dir string
-
-	// Don't read anything from cache (but still write)
-	Force bool
-
-	// Don't read errors from cache (but still write)
-	ForceErrors bool
 }
 
 func newCache(options Options) *Cache {
 	if options.Dir == "" {
 		options.Dir = "gohttpdisk"
 	}
-	return &Cache{
-		Dir:         options.Dir,
-		Force:       options.Force,
-		ForceErrors: options.ForceErrors,
-	}
+	return &Cache{options.Dir}
 }
 
 // Get the cached data for a request. An empty byte array will be returned if

--- a/cache.go
+++ b/cache.go
@@ -13,13 +13,23 @@ import (
 type Cache struct {
 	// Directory where the cache is stored. Defaults to gohttpdisk.
 	Dir string
+
+	// Don't read anything from cache (but still write)
+	Force bool
+
+	// Don't read errors from cache (but still write)
+	ForceErrors bool
 }
 
 func newCache(options Options) *Cache {
 	if options.Dir == "" {
 		options.Dir = "gohttpdisk"
 	}
-	return &Cache{options.Dir}
+	return &Cache{
+		Dir:         options.Dir,
+		Force:       options.Force,
+		ForceErrors: options.ForceErrors,
+	}
 }
 
 // Get the cached data for a request. An empty byte array will be returned if


### PR DESCRIPTION
Three new options:
1. `Force`: Don't use anything from the cache (but still write).
2. `ForceErrors`: Don't use errors from the cache (but still write). This includes all networking errors as well as HTTP 40x and 50x responses.
3. `Logger`: Optional logger for logging network requests.